### PR TITLE
Fix command to run app on an Android device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Test [Cordova BLE plugin](https://github.com/don/cordova-plugin-ble-central) wit
 Android
 
     ionic platform add android
-    ionic run --device
+    ionic run Android
 
 iOS
 


### PR DESCRIPTION
The previous command was incorrect and would produce the following error:
> WARN: ionic.project has been renamed to ionic.config.json, please rename it.
 Using this version of Cordova with older version of cordova-ios is being deprecated. Consider upgrading to cordova-ios@4.0.0 or newer.
Error: The provided path "/Users/igorganapolsky/workspace/git/ionic/ionic-ble/platforms/ios" is not a Cordova iOS project.